### PR TITLE
feat: init dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+.editorconfig
+.gitignore
+.husky
+/.git
+/.github
+/integrations
+/node_modules
+/scripts
+/tests
+LICENSE
+README.md
+npm-debug.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM docker.io/library/node:18-alpine
+
+RUN apk add --no-cache tini
+ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/docker-entrypoint.sh"]
+
+WORKDIR /app
+EXPOSE 3000
+
+ARG NODE_ENV=production
+ENV NODE_ENV=${NODE_ENV}
+
+COPY ["package.json", "package-lock.json*", "./"]
+RUN npm ci
+
+COPY env.ini.sample ./env.ini
+COPY . .
+
+USER node
+CMD ["node", "index.js"]


### PR DESCRIPTION
Minimal `Dockerfile` as starting point. So far, without image build and publish automation.

Example usage from `docker-compose.yml`:
```yaml
services:
  metis-bff:
    build:
      context: ./metis-bff
    environment:
      PG_NAME: aiida
      PG_HOST: aiida-db
      PG_USER: tilde
      PG_PASSWORD: password
      API_SCHEMA: http
      API_HOST: aiida
      API_PORT: "7050"
      API_KEY: a-very-very-very-long-and-very-very-very-secret-string
    ports:
      - "28001:3000"

```