### PR TITLE
logout callback for passport >=0.6

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,7 +68,7 @@ app.use((err, req, res, next) => {
 
     console.error(error);
 
-    if (!req.user) req.logout();
+    if (!req.user) req.logout(function (err) { if (err) { return next(err); } });
 
     if (res.headersSent) {
         res.sse.sendTo({ reqId: req.id, data: [error] }, 'errors');

--- a/routes/[version]/auth/index.js
+++ b/routes/[version]/auth/index.js
@@ -80,6 +80,6 @@ async function post(req, res, next) {
 }
 
 async function del(req, res) {
-    req.logout();
+    req.logout(function (err) { if (err) { return next(err); } });
     return res.status(StatusCodes.NO_CONTENT).end();
 }


### PR DESCRIPTION
BFF just doesn't work with fresh `node_modules` because `logout()` signature changed in `passport` 0.6.0. It throws an exception in middleware on every request.

[logout() documentation](https://github.com/passport/www.passportjs.org/blob/master/docs/logout.md)
[Press release](https://medium.com/passportjs/fixing-session-fixation-b2b68619c51d)