### PR TITLE
Return 401 http code on failed local authentication

### DIFF
--- a/routes/[version]/auth/index.js
+++ b/routes/[version]/auth/index.js
@@ -31,7 +31,7 @@ passport.use(
                 if (user && match) {
                     done(null, user);
                 } else {
-                    done({ status: StatusCodes.BAD_REQUEST, error: 'Bad credentials' }, null);
+                    done({ status: StatusCodes.UNAUTHORIZED, error: 'Authentication failed' }, null);
                 }
             } catch (err) {
                 done(err, null);


### PR DESCRIPTION
Return 401 http code on failed local authentication instead of confusing 400.