### PR TITLE
build: add npm commands 'apidoc', 'apidoc-swagger'

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,13 +60,13 @@ Note, that the non-versioned routes without `/v0` will be redirected _as is_ to 
 The docs are generated with the `apidoc`:
 
 ```
-apidoc -i routes
+npm run apidoc
 ```
 
 and, optionally, `swagger`:
 
 ```
-apidoc-swagger -i routes
+npm run apidoc-swagger
 ```
 
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
         "oauth": "cd tests/oauth && node server",
         "test:oauth": "env OAUTH_TEST=true npm start",
         "format": "prettier --ignore-path .gitignore --write '**/*.js'",
-        "prepare": "husky install"
+        "prepare": "husky install",
+        "apidoc": "apidoc -i routes",
+        "apidoc-swagger": "apidoc-swagger -i routes"
     },
     "repository": {
         "type": "git",


### PR DESCRIPTION
Fix: command not found: apidoc