### PR TITLE
Support relatives for datasources

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "metis-bff",
-    "version": "0.4.5",
+    "version": "0.5.0",
     "private": true,
     "description": "Project Metis: user and data management layer (backend-for-frontend)",
     "main": "index.js",

--- a/routes/[version]/datasources/_helpers.js
+++ b/routes/[version]/datasources/_helpers.js
@@ -1,4 +1,8 @@
-const { insertUserDataSource, deleteUserDataSource } = require('../../../services/db');
+const {
+    insertUserDataSource,
+    deleteUserDataSource,
+    selectDataSourcesIdMap,
+} = require('../../../services/db');
 const { createDataSource, getDataSources, deleteDataSource } = require('../../../services/backend');
 
 module.exports = {
@@ -17,29 +21,46 @@ async function createAndSaveDataSource(userId, content, fmt, name) {
     return insertUserDataSource(userId, { uuid: data.uuid });
 }
 
-async function getAndPrepareDataSources(datasources = { data: [], total: 0 }) {
-    const { uuids, ds } = datasources.data.reduce(
-        (acc, { uuid, ...other }) => {
-            acc.uuids.push(uuid);
-            acc.ds.push(other);
-            return acc;
-        },
-        { uuids: [], ds: [] }
-    );
-
-    if (!uuids.length) return { data: [], total: 0 };
-
-    const { data = [] } = await getDataSources(uuids);
-
+/**
+ * Retrieves data sources from both local and remote sources and prepares
+ * them for display.
+ * @async
+ * @function
+ * @param {Object} datasources - The datasources object.
+ * @param {Array<Object>} [datasources.data=[]] - The local data sources.
+ * @returns {Promise<Object>} - The merged and prepared data sources.
+ * @throws {Error} - If there is an error retrieving the remote data sources.
+ * @example
+ * const { data, total } = await getAndPrepareDataSources({ data: localDataSources });
+ */
+async function getAndPrepareDataSources({ data = [] }) {
     if (!data.length) return { data: [], total: 0 };
 
-    datasources.data = data.reduce((acc, { uuid, ...data }) => {
-        const i = uuids.indexOf(uuid);
-        acc.push(Object.assign(data, ds[i]));
-        return acc;
-    }, []);
+    // Map UUIDs to local data sources
+    const localDataSourcesMap = new Map(data.map(({ uuid, ...otherProps }) => [uuid, otherProps]));
 
-    return datasources;
+    // Retrieve remote data sources from backend
+    const { data: remoteDataSources = [] } = await getDataSources(
+        Array.from(localDataSourcesMap.keys())
+    );
+    if (!remoteDataSources.length) return [];
+
+    // Retrieve mapping of UUIDs to local IDs for parents and children
+    const relativeUUIDs = remoteDataSources.flatMap((x) => [
+        ...(x.parents || []),
+        ...(x.children || []),
+    ]);
+    const idToUUIDMap = await selectDataSourcesIdMap([], relativeUUIDs);
+    const uuidToIDMap = new Map(Array.from(idToUUIDMap).map((x) => x.reverse()));
+
+    // Merge remote and local data sources
+    const merged = remoteDataSources.map(({ uuid, ...dataSource }) => ({
+        ...dataSource,
+        parents: (dataSource.parents || []).map((x) => uuidToIDMap.get(x)),
+        children: (dataSource.children || []).map((x) => uuidToIDMap.get(x)),
+        ...(localDataSourcesMap.get(uuid) || {}),
+    }));
+    return { data: merged, total: merged.length };
 }
 
 async function deleteAndClearDataSource(userId, id) {

--- a/services/db.js
+++ b/services/db.js
@@ -118,6 +118,7 @@ module.exports = {
     compareStringHash,
 
     selectUserDataSources,
+    selectDataSourcesIdMap,
     insertUserDataSource,
     deleteUserDataSource,
     delsertDataSourceCollections,
@@ -325,6 +326,28 @@ async function selectUserDataSources(user, query) {
     const types = await db.select().from(COLLECTIONS_TYPES_TABLE);
 
     return { data, total, types };
+}
+
+/**
+ * Returns a map of datasource IDs and their corresponding UUIDs.
+ *
+ * @async
+ * @function selectDataSourcesIdMap
+ * @param {number[]} ids - An array of datasource IDs to query. Optional.
+ * @param {string[]} uuids - An array of datasource UUIDs to query. Optional.
+ * @returns {Promise<Map.<number, string>>} A map of datasource IDs and their corresponding UUIDs.
+ */
+async function selectDataSourcesIdMap(ids = [], uuids = []) {
+    if (!ids.length && !uuids.length) return {};
+    const idField = `${USER_DATASOURCES_TABLE}.id`;
+    const uuidField = `${USER_DATASOURCES_TABLE}.uuid`;
+    const data = await db(USER_DATASOURCES_TABLE)
+        .select(idField, uuidField)
+        .where((builder) => {
+            if (ids.length) builder.orWhereIn(idField, ids);
+            if (uuids.length) builder.orWhereIn(uuidField, uuids);
+        });
+    return new Map(data.map(({ id, uuid }) => [id, uuid]));
 }
 
 async function selectUserCollections(user, query) {


### PR DESCRIPTION
Add `selectDataSourcesIdMap()`.
Add support for `children` and `parents` fields to `getAndPrepareDataSources()`