### PR TITLE
Check that session middleware exists

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,11 +77,12 @@ app.use((err, req, res, next) => {
     console.error(error);
 
     if (!req.user)
-        req.logout(function (err) {
-            if (err) {
-                return next(err);
-            }
-        });
+        req.session &&
+            req.logout(function (err) {
+                if (err) {
+                    return next(err);
+                }
+            });
 
     if (res.headersSent) {
         res.sse.sendTo({ reqId: req.id, data: [error] }, 'errors');


### PR DESCRIPTION
Fix this error on failed authentication by api key:
```
{ status: 401, error: 'Authentication failed' }
Error: Login sessions require session support. Did you forget to use `express-session` middleware?
    at SessionManager.logOut (/app/node_modules/passport/lib/sessionmanager.js:64:33)
    at req.logout.req.logOut (/app/node_modules/passport/lib/http/request.js:67:26)
    at /app/index.js:80:13
    at Layer.handle_error (/app/node_modules/express/lib/router/layer.js:71:5)
    at trim_prefix (/app/node_modules/express/lib/router/index.js:321:13)
    at /app/node_modules/express/lib/router/index.js:284:7
    at Function.process_params (/app/node_modules/express/lib/router/index.js:341:12)
    at next (/app/node_modules/express/lib/router/index.js:275:10)
    at Layer.handle_error (/app/node_modules/express/lib/router/layer.js:67:12)
    at trim_prefix (/app/node_modules/express/lib/router/index.js:321:13)
{ status: 401, error: 'Authentication failed' }
Error: Login sessions require session support. Did you forget to use `express-session` middleware?
    at SessionManager.logOut (/app/node_modules/passport/lib/sessionmanager.js:64:33)
    at req.logout.req.logOut (/app/node_modules/passport/lib/http/request.js:67:26)
    at /app/index.js:80:13
    at Layer.handle_error (/app/node_modules/express/lib/router/layer.js:71:5)
    at trim_prefix (/app/node_modules/express/lib/router/index.js:321:13)
    at /app/node_modules/express/lib/router/index.js:284:7
    at Function.process_params (/app/node_modules/express/lib/router/index.js:341:12)
    at next (/app/node_modules/express/lib/router/index.js:275:10)
    at Layer.handle_error (/app/node_modules/express/lib/router/layer.js:67:12)
    at trim_prefix (/app/node_modules/express/lib/router/index.js:321:13)
```

Submitted by @blokhin

@pyoner Please, review.